### PR TITLE
Add CONTRIBUTING.md and clarify maintainer status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ To make a good PR, follow these steps:
 ### Maintainers
 
 * The original author of the package is Ed Scheinerman (@scheinerman), retaining authority over the development of the package as a co-maintainer.
-* The current maintainer of the package is Sánchez Ramírez (@mofeing).
+* The current maintainer of the package is Sergio Sánchez Ramírez (@mofeing).
 * Michael Goerz (@goerz) is a contributor with commit access for administrative purposes
 
 ### PR review and merging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Everyone is welcome to contribute! You can contribute via simply opening Issues reporting bugs or requesting features.
+
+## Pull Request Contributions
+
+The best way to contribute is by doing a Pull Request that fixes a bug or implements a new feature.
+
+However, before opening the PR, consider first discussing the change you wish to make via an issue, so that a good design can be discussed.
+
+To make a good PR, follow these steps:
+
+1. Ensure all tests pass locally before starting the pull request.
+2. Add adequate description in the Pull Request, or cite the corresponding issue if one exists by using `#` and the issue number.
+3. Always allow the "editing from maintainers" option in your PR.
+4. Update the CHANGELOG.md with details of the (notable) changes to the exported API.
+5. Feel free to explicitly tag (with `@`) one of the maintainers to request a review of your PR when it is ready.
+
+
+## Maintainer Notes
+
+### Maintainers
+
+* The original author of the package is Ed Scheinerman (@scheinerman), retaining authority over the development of the package as a co-maintainer.
+* The current maintainer of the package is Sánchez Ramírez (@mofeing).
+* Michael Goerz (@goerz) is a contributor with commit access for administrative purposes
+
+### PR review and merging
+
+* PRs can be merged by anyone with commit access.
+* PRs by authors with commit access can be self-merged after approval from a (co-)maintainer, or directly (without review) for trivial PRs

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Bijections"
 uuid = "e2ed5e7c-b2de-5872-ae92-c73ca462fb04"
-authors = ["Ed Scheinerman <ers@jhu.edu>"]
+authors = ["Ed Scheinerman <ers@jhu.edu>", "Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>"]
 version = "0.2.2"
 
 [compat]


### PR DESCRIPTION
Continuing https://github.com/JuliaCollections/Bijections.jl/pull/22#issuecomment-2916535818, we should probably clarify roles and responsibilities, and who will do things like merge PRs or handle the registration of `v1.0.0`.

I still think @mofeing would be the most natural maintainer of the package, going forward (in which case we'll adjust this PR to reflect that).