### PR TITLE
Improve serialization size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Moved project to the [JuliaCollections org](https://github.com/JuliaCollections)
+* Optimized `Serialization.serialize` size by saving only the forward dictionary
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Moved project to the [JuliaCollections org](https://github.com/JuliaCollections)
-* Optimized `Serialization.serialize` size by saving only the forward dictionary
+* Optimized `Serialization.serialize` size by saving only the forward dictionary (#34)
 
 ### Breaking
 

--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,15 @@ uuid = "e2ed5e7c-b2de-5872-ae92-c73ca462fb04"
 authors = ["Ed Scheinerman <ers@jhu.edu>", "Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>"]
 version = "0.2.2"
 
+[weakdeps]
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[extensions]
+BijectionsSerializationExt = "Serialization"
+
 [compat]
-julia = "1"
+Serialization = "1.6.0"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,9 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [extensions]
 BijectionsSerializationExt = "Serialization"
 
+[extras]
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
 [compat]
 Serialization = "1.6.0"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,3 @@ BijectionsSerializationExt = "Serialization"
 [compat]
 Serialization = "1.6.0"
 julia = "1.6"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/ext/BijectionsSerializationExt.jl
+++ b/ext/BijectionsSerializationExt.jl
@@ -1,0 +1,21 @@
+module BijectionsSerializationExt
+
+using Bijections
+using Serialization
+
+function Serialization.serialize(s::AbstractSerializer, b::B) where {B<:Bijection}
+    Serialization.writetag(s.io, Serialization.OBJECT_TAG)
+
+    # serialize type
+    serialize(s, B)
+
+    # serialize forward dictionary
+    return serialize(s, b.f)
+end
+
+function Serialization.deserialize(s::AbstractSerializer, ::Type{B}) where {B<:Bijection}
+    f = deserialize(s)
+    return b = B(f)
+end
+
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,7 @@
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Bijections = "e2ed5e7c-b2de-5872-ae92-c73ca462fb04"
+
+[sources]
+Bijections = {path = ".."}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,7 +265,8 @@ end
 @testset "Serialization" begin
     using Serialization
 
-    @testset let b = Bijection{Int,Symbol}(1 => :one, 2 => :two)
+    @testset "b = Bijection{Int,Symbol}(1 => :one, 2 => :two)" begin
+        b = Bijection{Int,Symbol}(1 => :one, 2 => :two)
         write_io = IOBuffer()
         serialize(write_io, b)
         data = take!(write_io)
@@ -278,7 +279,8 @@ end
         @test b_reconstructed.finv == b.finv
     end
 
-    @testset let b = Bijection{Int,Vector{Int}}(1 => [1], 2 => [2])
+    @testset "b = Bijection{Int,Vector{Int}}(1 => [1], 2 => [2])" begin
+        b = Bijection{Int,Vector{Int}}(1 => [1], 2 => [2])
         write_io = IOBuffer()
         serialize(write_io, b)
         data = take!(write_io)
@@ -291,9 +293,8 @@ end
         @test b_reconstructed.finv == b.finv
     end
 
-    @testset let b = Bijection{
-            Int,Vector{Int},Dict{Int,Vector{Int}},IdDict{Vector{Int},Int}
-        }(
+    @testset "b = Bijection{Int,Vector{Int},Dict{Int,Vector{Int}},IdDict{Vector{Int},Int}}(1 => [1], 2 => [1])" begin
+        b = Bijection{Int,Vector{Int},Dict{Int,Vector{Int}},IdDict{Vector{Int},Int}}(
             1 => [1],
             2 => [1], # value repeated on purpose
         )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,7 +265,7 @@ end
 @testset "Serialization" begin
     using Serialization
 
-    @testset "b = Bijection{Int,Symbol}(1 => :one, 2 => :two)" begin
+    @testset "bijection with immutable keys / values" begin
         b = Bijection{Int,Symbol}(1 => :one, 2 => :two)
         write_io = IOBuffer()
         serialize(write_io, b)
@@ -279,7 +279,7 @@ end
         @test b_reconstructed.finv == b.finv
     end
 
-    @testset "b = Bijection{Int,Vector{Int}}(1 => [1], 2 => [2])" begin
+    @testset "bijection with mutable values" begin
         b = Bijection{Int,Vector{Int}}(1 => [1], 2 => [2])
         write_io = IOBuffer()
         serialize(write_io, b)
@@ -293,7 +293,7 @@ end
         @test b_reconstructed.finv == b.finv
     end
 
-    @testset "b = Bijection{Int,Vector{Int},Dict{Int,Vector{Int}},IdDict{Vector{Int},Int}}(1 => [1], 2 => [1])" begin
+    @testset "bijection with mutable values + IdDict" begin
         b = Bijection{Int,Vector{Int},Dict{Int,Vector{Int}},IdDict{Vector{Int},Int}}(
             1 => [1],
             2 => [1], # value repeated on purpose


### PR DESCRIPTION
@goerz should we put the Serialization code in a extension or in the main module?

## Before

```julia
julia> d = Dict([i => 2i for i in 1:10_000]);

julia> b = Bijection(d);

julia> function measure_size(x)
           io = IOBuffer()
           serialize(io, x)
           length(take!(io))
       end

julia> measure_size(d)
99840

julia> measure_size(b)
199714
```

## After

```julia
julia> measure_size(b)
99898
```
