### PR TITLE
Define custom `dict_inverse(d::Base.ImmutableDict)`

### DIFF
--- a/src/Bijections.jl
+++ b/src/Bijections.jl
@@ -167,7 +167,7 @@ end
 
 function dict_inverse(d::D) where {D<:AbstractDict}
     allunique(values(d)) || throw(ArgumentError("dict is not bijective"))
-    return inverse_dict_type(D)(reverse.(collect(d))...)
+    return inverse_dict_type(D)(reverse.(collect(d)))
 end
 
 function dict_inverse(d::Base.ImmutableDict{K,V}) where {K,V}

--- a/src/Bijections.jl
+++ b/src/Bijections.jl
@@ -167,7 +167,18 @@ end
 
 function dict_inverse(d::D) where {D<:AbstractDict}
     allunique(values(d)) || throw(ArgumentError("dict is not bijective"))
-    return inverse_dict_type(D)(reverse.(collect(d)))
+    return inverse_dict_type(D)(reverse.(collect(d))...)
+end
+
+function dict_inverse(d::Base.ImmutableDict{K,V}) where {K,V}
+    # ImmutableDict does not have a ImmutableDict{K,V}(pairs...) constructor
+    # The version of the constructor with type parameters was overlooked in
+    # https://github.com/JuliaLang/julia/issues/35863
+    d_inv = Base.ImmutableDict{V,K}()
+    for (k, v) in reverse.(collect(d))
+        d_inv = Base.ImmutableDict{V,K}(d_inv, k, v)
+    end
+    return d_inv
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,13 @@ end
     @test length(b) == 2
     @test b["one"] == 1
     @test b["two"] == 2
+
+    # test construction from ImmutableDict
+    d = Base.ImmutableDict(1 => "one", 2 => "two")
+    b = Bijection(d)
+    @test length(b) == 2
+    @test b[1] == "one"
+    @test b[2] == "two"
 end
 
 # Test inv function


### PR DESCRIPTION
The default `dict_inverse` does not work for `ImmutableDict`, because `ImmutableDict` does not implement a `ImmutableDict{K,V}(pairs...)` constructor.

Closes #43